### PR TITLE
fix(react-hook-form): update Controller component type definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v0.0.8 (unrelease)
 
 - Add `useWatch` hook
+- Updated Controller component type definition in react-hook-form: made name parameter required and rules parameter optional
 
 # v0.0.7
 

--- a/doc/transformation.md
+++ b/doc/transformation.md
@@ -81,9 +81,9 @@ module ControllerOfInputs = {
 
   @module("react-hook-form") @react.component
   external make: (
-    ~name: variantOfInputs=?,
+    ~name: variantOfInputs,
     ~control: controlOfInputs=?,
-    ~rules: controllerRulesOfInputs,
+    ~rules: controllerRulesOfInputs=?,
     ~render: controllerFieldsOfInputs => React.element=?,
   ) => React.element = "Controller"
 }

--- a/src/ppx/signature.ml
+++ b/src/ppx/signature.ml
@@ -539,9 +539,9 @@ let map_type_decl
                       ];
                     (* @module("react-hook-form") @react.component
                        external make: (
-                         ~name: variantOfInputs=?,
+                         ~name: variantOfInputs,
                          ~control: controlOfInputs=?,
-                         ~rules: controllerRulesOfInputs,
+                         ~rules: controllerRulesOfInputs=?,
                          ~render: controllerFieldsOfInputs => React.element=?,
                        ) => React.element = "Controller" *)
                     Sig.value
@@ -564,17 +564,17 @@ let map_type_decl
                                 (Typ.constr ~attrs:[ attr_named_arg ]
                                    (lid @@ "variantOf" ^ capitalize record_name)
                                    [])
-                                (Typ.arrow (Labelled "control")
+                                (Typ.arrow (Optional "control")
                                    (Typ.constr ~attrs:[ attr_named_arg ]
                                       (lid @@ "controlOf"
                                      ^ capitalize record_name)
                                       [])
-                                   (Typ.arrow (Labelled "rules")
+                                   (Typ.arrow (Optional "rules")
                                       (Typ.constr ~attrs:[ attr_named_arg ]
                                          (lid @@ "controllerRulesOf"
                                         ^ capitalize record_name)
                                          [])
-                                      (Typ.arrow (Labelled "render")
+                                      (Typ.arrow (Optional "render")
                                          (uncurried_core_type_arrow
                                             ~attrs:[ attr_named_arg ] ~arity:1
                                             [

--- a/src/ppx/structure.ml
+++ b/src/ppx/structure.ml
@@ -538,9 +538,9 @@ let map_type_decl
                       ];
                     (* @module("react-hook-form") @react.component
                        external make: (
-                         ~name: variantOfInputs=?,
+                         ~name: variantOfInputs,
                          ~control: controlOfInputs=?,
-                         ~rules: controllerRulesOfInputs,
+                         ~rules: controllerRulesOfInputs=?,
                          ~render: controllerFieldsOfInputs => React.element=?,
                        ) => React.element = "Controller" *)
                     Str.primitive
@@ -563,17 +563,17 @@ let map_type_decl
                                 (Typ.constr ~attrs:[ attr_named_arg ]
                                    (lid @@ "variantOf" ^ capitalize record_name)
                                    [])
-                                (Typ.arrow (Labelled "control")
+                                (Typ.arrow (Optional "control")
                                    (Typ.constr ~attrs:[ attr_named_arg ]
                                       (lid @@ "controlOf"
                                      ^ capitalize record_name)
                                       [])
-                                   (Typ.arrow (Labelled "rules")
+                                   (Typ.arrow (Optional "rules")
                                       (Typ.constr ~attrs:[ attr_named_arg ]
                                          (lid @@ "controllerRulesOf"
                                         ^ capitalize record_name)
                                          [])
-                                      (Typ.arrow (Labelled "render")
+                                      (Typ.arrow (Optional "render")
                                          (uncurried_core_type_arrow
                                             ~attrs:[ attr_named_arg ] ~arity:1
                                             [


### PR DESCRIPTION
- Make `name` parameter required instead of optional
- Make `rules` parameter optional instead of required
- Change labeled arguments to optional in type definitions